### PR TITLE
chore(ci): bump actions/checkout from v2 to v7

### DIFF
--- a/.github/workflows/publish-release-package.yml
+++ b/.github/workflows/publish-release-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/publish-sanpshot-package.yml
+++ b/.github/workflows/publish-sanpshot-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from `@v2` to `@v7` (current stable release).
- `v2` is well past EOL; `v7` is the current major version.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>